### PR TITLE
Fixes deathriplys armor being halfed 

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -80,6 +80,7 @@
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE"
 	name = "\improper DEATH-RIPLEY"
 	icon_state = "deathripley"
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	slow_pressure_step_in = 3
 	opacity=0
 	lights_power = 7


### PR DESCRIPTION
[Changelogs]
Deathriplys armor is now back to the way it was
:cl: optional name here
fix: restores the deathriplys missing armor
/:cl:

[why]
I think Coolgate didnt mean to nerf the deathriplys armor. Besides its a Nukie mech, it would be better in armor class then basic NT mining mechs
